### PR TITLE
Parametric neutral+charged model (g1,g2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ using xDDPhaseSpace for 3-body phase space and supporting analytic continuation.
 ```julia
 using X3872ThreeBodyLineshape
 
-model = X3872ThreeBody(Ef_MeV=0.0, g=0.1, Γ0_MeV=0.0; channel=:neutral)
-D = denominator(model, 1.0)      # E in MeV
+model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.1, g_charged=0.0, Γ0_MeV=0.0)
+D = denominator(model, 1.0)      # E in MeV (relative to neutral threshold)
 L = lineshape(model, 1.0)        # |1/D|^2
-ρ = rho_thr(model, 1.0)          # (pi, gamma, total)
+ρ = rho_thr(model, 1.0)          # (neutral, charged, total)
 ```
 
 ## Parameters (defaults)

--- a/docs/example.md
+++ b/docs/example.md
@@ -3,12 +3,12 @@
 ```julia
 using X3872ThreeBodyLineshape
 
-model = X3872ThreeBody(Ef_MeV=0.0, g=0.1, Γ0_MeV=0.0; channel=:neutral)
+model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.1, g_charged=0.0, Γ0_MeV=0.0)
 E = range(-2.0, 2.0, length=200)
 L = [lineshape(model, e) for e in E]
 
-# charged channel
-model_c = X3872ThreeBody(Ef_MeV=0.0, g=0.1, Γ0_MeV=0.0; channel=:charged)
+# include charged channel
+model_c = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.1, g_charged=0.1, Γ0_MeV=0.0)
 L_c = [lineshape(model_c, e) for e in E]
 ```
 

--- a/src/X3872ThreeBodyLineshape.jl
+++ b/src/X3872ThreeBodyLineshape.jl
@@ -3,7 +3,6 @@ module X3872ThreeBodyLineshape
 import Base: denominator
 
 using xDDPhaseSpace
-using Parameters
 
 export X3872ThreeBody, default_constants, build_channels
 export rho_thr, denominator, lineshape
@@ -29,78 +28,91 @@ function default_constants()
 end
 
 """
-    build_channels(; channel=:neutral, constants=default_constants())
+    build_channels(; constants=default_constants())
 
-Construct the (πDD, γDD) channels for the requested charge configuration.
+Construct the (πDD, γDD) channels for neutral and charged configurations.
 """
-function build_channels(; channel::Symbol = :neutral, constants = default_constants())
-    if channel === :neutral
-        BW0 = BW(m = constants.mDstar0, Γ = constants.ΓDstar0)
-        ch_pi = πDD((m1 = constants.mπ0, m2 = constants.mD0, m3 = constants.mD0), BW0, BW0)
-        ch_gamma = γDD(
-            (m1 = constants.mγ, m2 = constants.mD0, m3 = constants.mD0),
-            BW0, BW0,
-            constants.μ0, -constants.μ0
-        )
-        thr = constants.mDstar0 + constants.mD0
-        return (pi = ch_pi, gamma = ch_gamma, threshold = thr)
-    elseif channel === :charged
-        BWc = BW(m = constants.mDstarp, Γ = constants.ΓDstarp)
-        ch_pi = πDD((m1 = constants.mπp, m2 = constants.mDp, m3 = constants.mDp), BWc, BWc)
-        ch_gamma = γDD(
-            (m1 = constants.mγ, m2 = constants.mDp, m3 = constants.mDp),
-            BWc, BWc,
-            constants.μp, -constants.μp
-        )
-        thr = constants.mDstarp + constants.mDp
-        return (pi = ch_pi, gamma = ch_gamma, threshold = thr)
-    else
-        error("Unsupported channel: $channel (use :neutral or :charged)")
-    end
+function build_channels(; constants = default_constants())
+    # neutral
+    BW0 = BW(m = constants.mDstar0, Γ = constants.ΓDstar0)
+    ch_pi0 = πDD((m1 = constants.mπ0, m2 = constants.mD0, m3 = constants.mD0), BW0, BW0)
+    ch_gamma0 = γDD(
+        (m1 = constants.mγ, m2 = constants.mD0, m3 = constants.mD0),
+        BW0, BW0,
+        constants.μ0, -constants.μ0
+    )
+    thr0 = constants.mDstar0 + constants.mD0
+
+    # charged
+    BWc = BW(m = constants.mDstarp, Γ = constants.ΓDstarp)
+    ch_pic = πDD((m1 = constants.mπp, m2 = constants.mDp, m3 = constants.mDp), BWc, BWc)
+    ch_gammac = γDD(
+        (m1 = constants.mγ, m2 = constants.mDp, m3 = constants.mDp),
+        BWc, BWc,
+        constants.μp, -constants.μp
+    )
+    thrc = constants.mDstarp + constants.mDp
+
+    return (
+        neutral = (pi = ch_pi0, gamma = ch_gamma0, threshold = thr0),
+        charged = (pi = ch_pic, gamma = ch_gammac, threshold = thrc)
+    )
 end
 
-"""Model container for three-body X(3872) lineshape."""
-@with_kw struct X3872ThreeBody{T<:Real}
+"""Model container for three-body X(3872) lineshape (neutral + charged)."""
+struct X3872ThreeBody{T<:Real}
     Ef_MeV::T
-    g::T
+    g_neutral::T
+    g_charged::T
     Γ0_MeV::T
-    channel::Symbol = :neutral
-    constants::NamedTuple = default_constants()
+    constants::NamedTuple
+    channels::NamedTuple
+end
+
+function X3872ThreeBody(; Ef_MeV::Real, g_neutral::Real, g_charged::Real, Γ0_MeV::Real, constants = default_constants())
+    channels = build_channels(; constants)
+    return X3872ThreeBody(Ef_MeV, g_neutral, g_charged, Γ0_MeV, constants, channels)
 end
 
 """
     rho_thr(model::X3872ThreeBody, E)
 
-Three-body phase-space density at energy offset E (MeV) relative to threshold.
-Returns a NamedTuple with π and γ contributions and their sum.
+Three-body phase-space density at energy offset E (MeV) relative to the neutral threshold.
+Returns neutral and charged contributions plus totals.
 """
 function rho_thr(model::X3872ThreeBody, E)
-    ch = build_channels(; channel = model.channel, constants = model.constants)
-    m = ch.threshold + E * 1e-3
-    ρπ = xDDPhaseSpace.ρ_thr(ch.pi, m)
-    ργ = xDDPhaseSpace.ρ_thr(ch.gamma, m)
-    return (pi = ρπ, gamma = ργ, total = ρπ + ργ)
+    ch0 = model.channels.neutral
+    chc = model.channels.charged
+    m = ch0.threshold + E * 1e-3
+    safe_rho(ch, mval) = isreal(mval) && mval < sum(masses(ch)) ? 0.0 : xDDPhaseSpace.ρ_thr(ch, mval)
+    ρπ0 = safe_rho(ch0.pi, m)
+    ργ0 = safe_rho(ch0.gamma, m)
+    ρπc = safe_rho(chc.pi, m)
+    ργc = safe_rho(chc.gamma, m)
+    return (
+        neutral = (pi = ρπ0, gamma = ργ0, total = ρπ0 + ργ0),
+        charged = (pi = ρπc, gamma = ργc, total = ρπc + ργc),
+        total = (ρπ0 + ργ0) + (ρπc + ργc)
+    )
 end
 
 """
     denominator(model::X3872ThreeBody, E)
 
-Denominator of the three-body amplitude. E is in MeV.
+Denominator of the three-body amplitude. E is in MeV (relative to neutral threshold).
 """
 function denominator(model::X3872ThreeBody, E)
-    @unpack Ef_MeV, g, Γ0_MeV = model
-    ρ = rho_thr(model, E)
-    return (Ef_MeV - E) * 1e-3 + 1im * Γ0_MeV / 2 + 1im * g * ρ.total
+    Eρ = isreal(E) ? E : real(E)
+    ρ = rho_thr(model, Eρ)
+    return (model.Ef_MeV - E) * 1e-3 + 1im * model.Γ0_MeV / 2 +
+        1im * (model.g_neutral * ρ.neutral.total + model.g_charged * ρ.charged.total)
 end
 
 """Lineshape (unnormalized): |1/denominator|^2."""
 lineshape(model::X3872ThreeBody, E) = abs2(inv(denominator(model, E)))
 
-# convenience wrappers
-rho_thr(E; channel::Symbol = :neutral, constants = default_constants()) =
-    rho_thr(X3872ThreeBody(; Ef_MeV = 0.0, g = 1.0, Γ0_MeV = 0.0, channel, constants), E)
-
-lineshape(E; channel::Symbol = :neutral, Ef_MeV::Real, g::Real, Γ0_MeV::Real, constants = default_constants()) =
-    lineshape(X3872ThreeBody(; Ef_MeV, g, Γ0_MeV, channel, constants), E)
+# convenience wrapper
+lineshape(E; Ef_MeV::Real, g_neutral::Real, g_charged::Real, Γ0_MeV::Real, constants = default_constants()) =
+    lineshape(X3872ThreeBody(; Ef_MeV, g_neutral, g_charged, Γ0_MeV, constants), E)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,37 +2,37 @@ using Test
 using X3872ThreeBodyLineshape
 
 @testset "rho_thr neutral" begin
-    model = X3872ThreeBody(Ef_MeV=0.0, g=1.0, Γ0_MeV=0.0; channel=:neutral)
+    model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=1.0, g_charged=0.0, Γ0_MeV=0.0)
     ρ = rho_thr(model, 1.0)
-    @test isfinite(ρ.pi)
-    @test isfinite(ρ.gamma)
-    @test ρ.total > 0
+    @test isfinite(ρ.neutral.pi)
+    @test isfinite(ρ.neutral.gamma)
+    @test ρ.neutral.total > 0
 end
 
 @testset "lineshape neutral" begin
-    model = X3872ThreeBody(Ef_MeV=0.0, g=0.1, Γ0_MeV=0.0; channel=:neutral)
+    model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.1, g_charged=0.0, Γ0_MeV=0.0)
     val = lineshape(model, 1.0)
     @test isfinite(val)
     @test val > 0
 end
 
 @testset "neutral ratio sanity" begin
-    model = X3872ThreeBody(Ef_MeV=0.0, g=1.0, Γ0_MeV=0.0; channel=:neutral)
+    model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=1.0, g_charged=0.0, Γ0_MeV=0.0)
     ρ = rho_thr(model, 1.0)
-    ratio = ρ.pi / ρ.gamma
+    ratio = ρ.neutral.pi / ρ.neutral.gamma
     @test ratio > 0.5 && ratio < 5.0
 end
 
 @testset "analytic continuation" begin
-    model = X3872ThreeBody(Ef_MeV=0.0, g=0.1, Γ0_MeV=0.0; channel=:neutral)
+    model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.1, g_charged=0.0, Γ0_MeV=0.0)
     D = denominator(model, 1.0 + 1.0im)
     @test isfinite(real(D)) && isfinite(imag(D))
 end
 
 @testset "rho_thr charged" begin
-    model = X3872ThreeBody(Ef_MeV=0.0, g=1.0, Γ0_MeV=0.0; channel=:charged)
+    model = X3872ThreeBody(Ef_MeV=0.0, g_neutral=0.0, g_charged=1.0, Γ0_MeV=0.0)
     ρ = rho_thr(model, 1.0)
-    @test isfinite(ρ.pi)
-    @test isfinite(ρ.gamma)
-    @test ρ.total > 0
+    @test isfinite(ρ.charged.pi)
+    @test isfinite(ρ.charged.gamma)
+    @test ρ.charged.total > 0
 end


### PR DESCRIPTION
Fixes #2. Introduces X3872ThreeBody with g_neutral/g_charged and combined neutral+charged phase space; updates tests and docs.